### PR TITLE
:art: update: add close button to toast notifications and adjust font size

### DIFF
--- a/content.js
+++ b/content.js
@@ -62,6 +62,12 @@ function showToast(type, message, source, duration = 2000) {
   const toast = document.createElement("div");
   toast.id = TOAST_ID;
 
+  const closeButton = document.createElement("div");
+  closeButton.className = "close-button";
+  closeButton.textContent = "\u00d7";
+  closeButton.addEventListener("click", () => removeToast());
+  toast.appendChild(closeButton);
+
   const typeElement = document.createElement("div");
   typeElement.className = "toast-type";
   typeElement.textContent = getTypeMessage(type);

--- a/toast.css
+++ b/toast.css
@@ -9,7 +9,7 @@
   border-radius: 8px;
   border: solid 2px #752;
   box-shadow: 3px 3px #752;;
-  font-size: 1em;
+  font-size: 0.8em;
   max-width: 30vw;
   word-break: break-all;
   animation: error-toast-in 0.3s;
@@ -27,4 +27,14 @@
 
 .toast-source {
   font-size: 0.8em;
+}
+
+.close-button {
+  position: absolute;
+  top: 0;
+  right: 16px;
+  cursor: pointer;
+  background: transparent;
+  font-size: 1.5em;
+  z-index: 9999;
 }


### PR DESCRIPTION
This pull request improves the user experience of the toast notifications by adding a close button to allow manual dismissal and adjusts the styling for better appearance and usability.

**Toast notification enhancements:**

* Added a close button to the toast notification in `content.js`, allowing users to manually dismiss toasts.
* Introduced `.close-button` styles in `toast.css` to position and style the close button for visibility and ease of use.

**Styling adjustments:**

* Reduced the font size of toast notifications in `toast.css` for a more compact look.