### PR TITLE
:art: update: change toast event from click to mousemove to extend display time

### DIFF
--- a/content.js
+++ b/content.js
@@ -85,7 +85,7 @@ function showToast(type, message, source, duration = 2000) {
     toast.appendChild(sourceElement);
   }
 
-  toast.addEventListener("click", () => {
+  toast.addEventListener("mousemove", () => {
     extendDisplayTime(duration);
   });
 


### PR DESCRIPTION
This pull request makes a minor update to the behavior of toast notifications in `content.js`, which improves the user experience by extending the display time on mouseover instead of when the toast is clicked.